### PR TITLE
feat: refactor so nodes are always valid utf-8

### DIFF
--- a/src/ast/from_node.rs
+++ b/src/ast/from_node.rs
@@ -10,7 +10,7 @@ use super::expressions::ParseExprError;
 /// Requires providing the text source, which is needed for extracting names and identifiers.
 pub trait FromNode: Sized {
     type Error;
-    fn from_node(node: &Node, text: impl AsRef<[u8]>) -> Result<Self, Self::Error>;
+    fn from_node(node: &Node, text: &str) -> Result<Self, Self::Error>;
 }
 
 // #[derive(Debug, Error, Clone)]
@@ -25,8 +25,6 @@ pub trait FromNode: Sized {
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 /// An error associated with converting a tree-sitter `Node`.
 pub enum FromNodeError {
-    #[error("Could not parse text as UTF-8 {0}")]
-    Utf8Error(std::str::Utf8Error),
     #[error("Could not parse text as int {0}")]
     ParseIntError(std::num::ParseIntError),
     #[error("Could not parse text as float {0}")]
@@ -69,7 +67,6 @@ impl<'a> IntoError<Node<'a>> for Option<Node<'a>> {
 impl diagnostics::Issue for SpannedError<FromNodeError> {
     fn diagnostic(&self) -> diagnostics::Diagnostic {
         let name = match self.error {
-            FromNodeError::Utf8Error(_) => "UTF-8 error",
             FromNodeError::ParseIntError(_) => "parsing int failed",
             FromNodeError::ParseFloatError(_) => "parsing float failed",
             FromNodeError::UnknownCommand { .. } => "unknown command",
@@ -103,12 +100,6 @@ impl From<std::num::ParseFloatError> for FromNodeError {
 impl From<std::num::ParseIntError> for FromNodeError {
     fn from(v: std::num::ParseIntError) -> Self {
         Self::ParseIntError(v)
-    }
-}
-
-impl From<std::str::Utf8Error> for FromNodeError {
-    fn from(v: std::str::Utf8Error) -> Self {
-        Self::Utf8Error(v)
     }
 }
 

--- a/src/check_commands/fixes/mod.rs
+++ b/src/check_commands/fixes/mod.rs
@@ -97,7 +97,7 @@ mod tests {
         let text = "fix profw water  ave/chunk 1 $(v_nsteps) $(v_nsteps) lwater  density/number density/mass  temp file ${outputname}water.profiles adof 2";
         let tree = parse(text);
         let node = tree.root_node().child(0).unwrap();
-        let fix = FixDef::from_node(&node, text.as_bytes()).unwrap();
+        let fix = FixDef::from_node(&node, text).unwrap();
 
         dbg!(&fix);
 
@@ -109,7 +109,7 @@ mod tests {
         let text = "fix profw water  ave/chunk 1 $(v_nsteps) $(v_nsteps)";
         let tree = parse(text);
         let node = tree.root_node().child(0).unwrap();
-        let fix = FixDef::from_node(&node, text.as_bytes()).unwrap();
+        let fix = FixDef::from_node(&node, text).unwrap();
 
         assert!(dbg!(fixes::check_fix(&fix)).is_err())
     }

--- a/src/check_commands/fixes/nose_hoover.rs
+++ b/src/check_commands/fixes/nose_hoover.rs
@@ -153,7 +153,7 @@ mod tests {
         let text = "fix NVT all nvt temp 1 $(v_T*1.5) $(100*dt)";
         let tree = parse(text);
         let node = tree.root_node().child(0).unwrap();
-        let fix = FixDef::from_node(&node, text.as_bytes()).unwrap();
+        let fix = FixDef::from_node(&node, text).unwrap();
 
         assert_eq!(fix.fix_id.name, "NVT");
         assert_eq!(fix.group_id.contents, "all");
@@ -168,7 +168,7 @@ mod tests {
         let text = "fix NPT all npt temp 1 $(v_T*1.5) $(100*dt) iso 1 $(v_p*1.5) ${pdamp}";
         let tree = parse(text);
         let node = tree.root_node().child(0).unwrap();
-        let fix = FixDef::from_node(&node, text.as_bytes()).unwrap();
+        let fix = FixDef::from_node(&node, text).unwrap();
 
         assert_eq!(fix.fix_id.name, "NPT");
         assert_eq!(fix.group_id.contents, "all");
@@ -183,7 +183,7 @@ mod tests {
         let text = "fix 2 ice nph x 1.0 1.0 0.5 y 2.0 2.0 0.5 z 3.0 3.0 0.5 yz 0.1 0.1 0.5 xz 0.2 0.2 0.5 xy 0.3 0.3 0.5 nreset 1000";
         let tree = parse(text);
         let node = tree.root_node().child(0).unwrap();
-        let fix = FixDef::from_node(&node, text.as_bytes()).unwrap();
+        let fix = FixDef::from_node(&node, text).unwrap();
 
         assert_eq!(fix.fix_id.name, "2");
         assert_eq!(fix.group_id.contents, "ice");
@@ -198,7 +198,7 @@ mod tests {
         let text = "fix NVT all nvt temp 1.0 $(v_T*1.5) TEMP";
         let tree = parse(text);
         let node = tree.root_node().child(0).unwrap();
-        let fix = FixDef::from_node(&node, text.as_bytes()).unwrap();
+        let fix = FixDef::from_node(&node, text).unwrap();
 
         assert_eq!(fix.fix_id.name, "NVT");
         assert_eq!(fix.group_id.contents, "all");

--- a/src/check_commands/utils.rs
+++ b/src/check_commands/utils.rs
@@ -167,7 +167,7 @@ mod tests {
         let text = "fix NVE all nve";
         let tree = parse(text);
         let node = tree.root_node().child(0).unwrap();
-        let fix = FixDef::from_node(&node, text.as_bytes()).unwrap();
+        let fix = FixDef::from_node(&node, text).unwrap();
 
         assert_eq!(fix.fix_id.name, "NVE");
         assert_eq!(fix.group_id.contents, "all");
@@ -182,7 +182,7 @@ mod tests {
         let text = "fix NVE all nve asdfas";
         let tree = parse(text);
         let node = tree.root_node().child(0).unwrap();
-        let fix = FixDef::from_node(&node, text.as_bytes()).unwrap();
+        let fix = FixDef::from_node(&node, text).unwrap();
 
         assert_eq!(fix.fix_id.name, "NVE");
         assert_eq!(fix.group_id.contents, "all");

--- a/src/input_script.rs
+++ b/src/input_script.rs
@@ -50,8 +50,7 @@ impl Debug for LmpParser {
 }
 
 impl<'src> InputScript<'src> {
-    /// Monolithic method that reads the lammps source code.
-    /// Parser is taken as input rather than stored because it does not implement debug.
+    /// Monolithic method that reads the lammps source code and reports errors.
     pub fn new(source_code: &'src str) -> Result<Self> {
         let mut parser = utils::parsing::setup_parser();
         let tree = parser

--- a/src/lints/mod.rs
+++ b/src/lints/mod.rs
@@ -89,7 +89,7 @@ mod tests {
 
     #[test]
     fn test_multiple_fix_defs() {
-        let text = b"fix NVT all nvt temp 1 1.5 $(100.0*dt)
+        let text = "fix NVT all nvt temp 1 1.5 $(100.0*dt)
                              fix NVT all nvt temp 1 1.5 $(100.0*dt)
                              run 10000
                              fix NVT all nvt temp 1 1.5 $(100.0*dt)";
@@ -110,7 +110,7 @@ mod tests {
 
     #[test]
     fn redefined_fix_after_run() {
-        let text = b"fix NVT all nvt temp 1 1.5 $(100.0*dt)
+        let text = "fix NVT all nvt temp 1 1.5 $(100.0*dt)
                              run 10000
                              fix NVT all nvt temp 1 1.5 $(100.0*dt)";
 
@@ -130,7 +130,7 @@ mod tests {
     // #[ignore = "Lint being tested is incomplete"]
     // TODO: Finish the lint so the test passes
     fn redefined_twice_after_first_run() {
-        let text = b"fix NVT all nvt temp 1 1.5 $(100.0*dt)
+        let text = "fix NVT all nvt temp 1 1.5 $(100.0*dt)
                              run 10000
                              fix NVT all nvt temp 1 1.5 $(100.0*dt)
                              fix NVT all nvt temp 1 1.5 $(100.0*dt)

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ struct Cli {
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    let source_code = std::fs::read_to_string(&cli.source)?;
+    let source_code = std::fs::read_to_string(&cli.source).context("file must be UTF-8 encoded")?;
     let mut parser = Parser::new();
 
     parser

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,6 +2,8 @@ use crate::spans::Point;
 
 use crate::identifinder::{IdentiFinder, NameAndType};
 
+pub(crate) mod tree_sitter_helpers;
+
 /// Find the symbol under the given point in the file
 pub(crate) fn get_symbol_at_point<'a>(
     identifinder: &'a IdentiFinder,

--- a/src/utils/tree_sitter_helpers.rs
+++ b/src/utils/tree_sitter_helpers.rs
@@ -1,0 +1,18 @@
+use tree_sitter::Node;
+
+/// An extension trait that adds addtional methods to `tree_sitter::Node`
+pub(crate) trait NodeExt {
+    /// A helper method for getting the text of a node from valid utf-8.
+    ///
+    /// # Panics
+    /// Panics if node offset somehow is on invalid UTF-8 character boundaries.
+    /// This should only happen if the file wasn't UTF-8 encoded.
+    fn str_text<'a>(&self, source: &'a str) -> &'a str;
+}
+
+impl NodeExt for Node<'_> {
+    fn str_text<'a>(&self, source: &'a str) -> &'a str {
+        // Shoul not panic as source is valid utf-8
+        self.utf8_text(source.as_bytes()).expect("invalid utf-8")
+    }
+}


### PR DESCRIPTION
This removes the need for the FromNodeError::Utf8Error variant, by always passing in a string slice instead of a `impl AsRef<[u8]>` into many methods

This is greatly assisted by adding an extension method `str_text` to `tree_sitter::Node` which is a simple wrapper around the `utf8_text` method but always takes in valid `utf-8`