### PR TITLE
Atom properties and Indexing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1136,9 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-lammps"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cb084efc92a24f0a0883023c2ace20ae30de0babe96c6dd59a2eb2750028a06"
+version = "0.0.5"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,6 +1137,8 @@ dependencies = [
 [[package]]
 name = "tree-sitter-lammps"
 version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac33c6f09df70517970981c29c7e39653aa65a9cc788bb964eb5df0241f0b23c"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,6 @@ exclude = ["/ci", "images/", ".*", "bacon.toml", "_typos.toml"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[patch.crates-io]
-tree-sitter-lammps = { path = "../tree-sitter-lammps" }
-
 [build-dependencies]
 cc = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ exclude = ["/ci", "images/", ".*", "bacon.toml", "_typos.toml"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[patch.crates-io]
+tree-sitter-lammps = { path = "../tree-sitter-lammps" }
+
 [build-dependencies]
 cc = "1.0"
 
@@ -34,7 +37,7 @@ tokio = { version = "1.40.0", features = [
 ] }
 tower-lsp = "0.20.0"
 tree-sitter = "0.23.0"
-tree-sitter-lammps = "0.0.4"
+tree-sitter-lammps = "0.0.5"
 
 [dev-dependencies]
 criterion = { version = "=0.5.1", features = ["html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,16 +17,16 @@ cc = "1.0"
 
 [dependencies]
 anyhow = "1.0.72"
-clap = { version = "4.3.19", features = ["derive"] }
-dashmap = "=6.1"
-itertools = "=0.13.0"
+clap = { version = "4.5", features = ["derive"] }
+dashmap = "6.1"
+itertools = "0.13.0"
 lsp-types = "0.94.1"
 once_cell = "1.19.0"
-owo-colors = { version = "=4.1", features = ["supports-colors"] }
+owo-colors = { version = "4.1", features = ["supports-colors"] }
 serde = "1.0.171"
 serde_json = "1.0.105"
 thiserror = "1.0.44"
-tokio = { version = "1.32.0", features = [
+tokio = { version = "1.40.0", features = [
     "io-std",
     "rt",
     "macros",

--- a/node_types.json
+++ b/node_types.json
@@ -50,6 +50,10 @@
             "named": true
           },
           {
+            "type": "indexed_ident",
+            "named": true
+          },
+          {
             "type": "int",
             "named": true
           },
@@ -360,6 +364,10 @@
       "required": true,
       "types": [
         {
+          "type": "atom_property",
+          "named": true
+        },
+        {
           "type": "binary_func",
           "named": true
         },
@@ -385,6 +393,10 @@
         },
         {
           "type": "hexnary_func",
+          "named": true
+        },
+        {
+          "type": "indexing",
           "named": true
         },
         {
@@ -612,9 +624,24 @@
     "fields": {}
   },
   {
-    "type": "indexing",
+    "type": "indexed_ident",
     "named": true,
-    "fields": {},
+    "fields": {
+      "ident": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "indexed_ident",
+            "named": true
+          },
+          {
+            "type": "underscore_ident",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": false,
       "required": true,
@@ -628,6 +655,36 @@
           "named": true
         }
       ]
+    }
+  },
+  {
+    "type": "indexing",
+    "named": true,
+    "fields": {
+      "index": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "glob",
+            "named": true
+          },
+          {
+            "type": "int",
+            "named": true
+          }
+        ]
+      },
+      "value": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "expression",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -914,7 +971,7 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
         {
@@ -923,10 +980,6 @@
         },
         {
           "type": "fix_id",
-          "named": true
-        },
-        {
-          "type": "indexing",
           "named": true
         },
         {
@@ -1167,6 +1220,10 @@
   {
     "type": "^",
     "named": false
+  },
+  {
+    "type": "atom_property",
+    "named": true
   },
   {
     "type": "atomfile",

--- a/node_types.json
+++ b/node_types.json
@@ -1,0 +1,1303 @@
+[
+  {
+    "type": "_statement",
+    "named": true,
+    "subtypes": [
+      {
+        "type": "command",
+        "named": true
+      },
+      {
+        "type": "compute",
+        "named": true
+      },
+      {
+        "type": "fix",
+        "named": true
+      },
+      {
+        "type": "shell",
+        "named": true
+      },
+      {
+        "type": "variable_def",
+        "named": true
+      },
+      {
+        "type": "variable_del",
+        "named": true
+      }
+    ]
+  },
+  {
+    "type": "args_under",
+    "named": true,
+    "fields": {
+      "arg": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "bool",
+            "named": true
+          },
+          {
+            "type": "concatenation",
+            "named": true
+          },
+          {
+            "type": "float",
+            "named": true
+          },
+          {
+            "type": "int",
+            "named": true
+          },
+          {
+            "type": "simple_expansion",
+            "named": true
+          },
+          {
+            "type": "string",
+            "named": true
+          },
+          {
+            "type": "underscore_ident",
+            "named": true
+          },
+          {
+            "type": "var_curly",
+            "named": true
+          },
+          {
+            "type": "var_round",
+            "named": true
+          },
+          {
+            "type": "word",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "binary_func",
+    "named": true,
+    "fields": {
+      "args": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
+          {
+            "type": ",",
+            "named": false
+          },
+          {
+            "type": "expression",
+            "named": true
+          }
+        ]
+      },
+      "function": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "binary_op",
+    "named": true,
+    "fields": {
+      "left": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "expression",
+            "named": true
+          }
+        ]
+      },
+      "operator": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "!=",
+            "named": false
+          },
+          {
+            "type": "%",
+            "named": false
+          },
+          {
+            "type": "&&",
+            "named": false
+          },
+          {
+            "type": "*",
+            "named": false
+          },
+          {
+            "type": "+",
+            "named": false
+          },
+          {
+            "type": "-",
+            "named": false
+          },
+          {
+            "type": "/",
+            "named": false
+          },
+          {
+            "type": "<",
+            "named": false
+          },
+          {
+            "type": "<=",
+            "named": false
+          },
+          {
+            "type": "==",
+            "named": false
+          },
+          {
+            "type": ">",
+            "named": false
+          },
+          {
+            "type": ">=",
+            "named": false
+          },
+          {
+            "type": "^",
+            "named": false
+          },
+          {
+            "type": "|^",
+            "named": false
+          },
+          {
+            "type": "||",
+            "named": false
+          }
+        ]
+      },
+      "right": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "expression",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "bool",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "false",
+          "named": true
+        },
+        {
+          "type": "true",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "command",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "args_under",
+          "named": true
+        },
+        {
+          "type": "command_name",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "command_name",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "compute",
+    "named": true,
+    "fields": {
+      "arguments": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "args_under",
+            "named": true
+          }
+        ]
+      },
+      "compute_id": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "compute_id",
+            "named": true
+          }
+        ]
+      },
+      "group": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "group_id",
+            "named": true
+          }
+        ]
+      },
+      "style": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "compute_style",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "compute_id",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "compute_style",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "concatenation",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "simple_expansion",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "var_curly",
+          "named": true
+        },
+        {
+          "type": "var_round",
+          "named": true
+        },
+        {
+          "type": "word",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "binary_func",
+          "named": true
+        },
+        {
+          "type": "binary_op",
+          "named": true
+        },
+        {
+          "type": "bool",
+          "named": true
+        },
+        {
+          "type": "constant",
+          "named": true
+        },
+        {
+          "type": "float",
+          "named": true
+        },
+        {
+          "type": "group_func",
+          "named": true
+        },
+        {
+          "type": "hexnary_func",
+          "named": true
+        },
+        {
+          "type": "int",
+          "named": true
+        },
+        {
+          "type": "other_func",
+          "named": true
+        },
+        {
+          "type": "parens",
+          "named": true
+        },
+        {
+          "type": "region_func",
+          "named": true
+        },
+        {
+          "type": "ternary_func",
+          "named": true
+        },
+        {
+          "type": "thermo_kwarg",
+          "named": true
+        },
+        {
+          "type": "unary_func",
+          "named": true
+        },
+        {
+          "type": "unary_op",
+          "named": true
+        },
+        {
+          "type": "underscore_ident",
+          "named": true
+        },
+        {
+          "type": "var_curly",
+          "named": true
+        },
+        {
+          "type": "var_round",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "fix",
+    "named": true,
+    "fields": {
+      "arguments": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "args_under",
+            "named": true
+          }
+        ]
+      },
+      "fix_id": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "fix_id",
+            "named": true
+          }
+        ]
+      },
+      "group": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "group_id",
+            "named": true
+          }
+        ]
+      },
+      "style": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "fix_style",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "fix_id",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "fix_style",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "glob",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "group_func",
+    "named": true,
+    "fields": {
+      "args": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
+          {
+            "type": "group_id",
+            "named": true
+          }
+        ]
+      },
+      "function": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "other_args": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": ",",
+            "named": false
+          },
+          {
+            "type": "expression",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "group_id",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "hexnary_func",
+    "named": true,
+    "fields": {
+      "args": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
+          {
+            "type": ",",
+            "named": false
+          },
+          {
+            "type": "expression",
+            "named": true
+          }
+        ]
+      },
+      "function": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "identifier",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "indexing",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "glob",
+          "named": true
+        },
+        {
+          "type": "int",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "input_script",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "other_func",
+    "named": true,
+    "fields": {
+      "args": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
+          {
+            "type": ",",
+            "named": false
+          },
+          {
+            "type": "expression",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "function": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "parens",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "quoted_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "region_func",
+    "named": true,
+    "fields": {
+      "args": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
+          {
+            "type": ",",
+            "named": false
+          },
+          {
+            "type": "group_id",
+            "named": true
+          }
+        ]
+      },
+      "function": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "other_args": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": ",",
+            "named": false
+          },
+          {
+            "type": "expression",
+            "named": true
+          }
+        ]
+      },
+      "region_id": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "shell",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "simple_expansion",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "variable",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "string",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "string_content",
+          "named": true
+        },
+        {
+          "type": "var_curly",
+          "named": true
+        },
+        {
+          "type": "var_round",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "ternary_func",
+    "named": true,
+    "fields": {
+      "args": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
+          {
+            "type": ",",
+            "named": false
+          },
+          {
+            "type": "expression",
+            "named": true
+          }
+        ]
+      },
+      "function": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "unary_func",
+    "named": true,
+    "fields": {
+      "args": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
+          {
+            "type": "expression",
+            "named": true
+          }
+        ]
+      },
+      "function": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "unary_op",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "underscore_ident",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "compute_id",
+          "named": true
+        },
+        {
+          "type": "fix_id",
+          "named": true
+        },
+        {
+          "type": "indexing",
+          "named": true
+        },
+        {
+          "type": "variable",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "var_curly",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "variable",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "var_round",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "variable",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "variable_def",
+    "named": true,
+    "fields": {
+      "args": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "concatenation",
+            "named": true
+          },
+          {
+            "type": "simple_expansion",
+            "named": true
+          },
+          {
+            "type": "string",
+            "named": true
+          },
+          {
+            "type": "var_curly",
+            "named": true
+          },
+          {
+            "type": "var_round",
+            "named": true
+          },
+          {
+            "type": "word",
+            "named": true
+          }
+        ]
+      },
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "variable",
+            "named": true
+          }
+        ]
+      },
+      "rhs": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "expression",
+            "named": true
+          },
+          {
+            "type": "quoted_expression",
+            "named": true
+          }
+        ]
+      },
+      "style": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "variable_style",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "variable_del",
+    "named": true,
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "variable",
+            "named": true
+          }
+        ]
+      },
+      "style": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "variable_style",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "variable_style",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "\n",
+    "named": false
+  },
+  {
+    "type": "!",
+    "named": false
+  },
+  {
+    "type": "!=",
+    "named": false
+  },
+  {
+    "type": "\"",
+    "named": false
+  },
+  {
+    "type": "$",
+    "named": false
+  },
+  {
+    "type": "$(",
+    "named": false
+  },
+  {
+    "type": "${",
+    "named": false
+  },
+  {
+    "type": "%",
+    "named": false
+  },
+  {
+    "type": "&&",
+    "named": false
+  },
+  {
+    "type": "(",
+    "named": false
+  },
+  {
+    "type": ")",
+    "named": false
+  },
+  {
+    "type": "*",
+    "named": false
+  },
+  {
+    "type": "+",
+    "named": false
+  },
+  {
+    "type": ",",
+    "named": false
+  },
+  {
+    "type": "-",
+    "named": false
+  },
+  {
+    "type": "/",
+    "named": false
+  },
+  {
+    "type": "<",
+    "named": false
+  },
+  {
+    "type": "<=",
+    "named": false
+  },
+  {
+    "type": "==",
+    "named": false
+  },
+  {
+    "type": ">",
+    "named": false
+  },
+  {
+    "type": ">=",
+    "named": false
+  },
+  {
+    "type": "[",
+    "named": false
+  },
+  {
+    "type": "]",
+    "named": false
+  },
+  {
+    "type": "^",
+    "named": false
+  },
+  {
+    "type": "atomfile",
+    "named": false
+  },
+  {
+    "type": "c_",
+    "named": false
+  },
+  {
+    "type": "comment",
+    "named": true
+  },
+  {
+    "type": "compute",
+    "named": false
+  },
+  {
+    "type": "constant",
+    "named": true
+  },
+  {
+    "type": "f_",
+    "named": false
+  },
+  {
+    "type": "false",
+    "named": true
+  },
+  {
+    "type": "file",
+    "named": false
+  },
+  {
+    "type": "fix",
+    "named": false
+  },
+  {
+    "type": "float",
+    "named": true
+  },
+  {
+    "type": "format",
+    "named": false
+  },
+  {
+    "type": "getenv",
+    "named": false
+  },
+  {
+    "type": "index",
+    "named": false
+  },
+  {
+    "type": "int",
+    "named": true
+  },
+  {
+    "type": "internal",
+    "named": false
+  },
+  {
+    "type": "loop",
+    "named": false
+  },
+  {
+    "type": "python",
+    "named": false
+  },
+  {
+    "type": "shell",
+    "named": false
+  },
+  {
+    "type": "string",
+    "named": false
+  },
+  {
+    "type": "string_content",
+    "named": true
+  },
+  {
+    "type": "thermo_kwarg",
+    "named": true
+  },
+  {
+    "type": "timer",
+    "named": false
+  },
+  {
+    "type": "true",
+    "named": true
+  },
+  {
+    "type": "uloop",
+    "named": false
+  },
+  {
+    "type": "universe",
+    "named": false
+  },
+  {
+    "type": "v_",
+    "named": false
+  },
+  {
+    "type": "variable",
+    "named": false
+  },
+  {
+    "type": "vector",
+    "named": false
+  },
+  {
+    "type": "word",
+    "named": true
+  },
+  {
+    "type": "world",
+    "named": false
+  },
+  {
+    "type": "|^",
+    "named": false
+  },
+  {
+    "type": "||",
+    "named": false
+  },
+  {
+    "type": "}",
+    "named": false
+  }
+]

--- a/src/ast/expressions.rs
+++ b/src/ast/expressions.rs
@@ -43,13 +43,20 @@ pub enum Expression {
     /// Thermo keyword
     /// TODO: Use an enum instead
     ThermoKeyword(Word),
+
+    /// Built-in atom property keyword
+    /// TODO: Use an enum instead
+    AtomProperty(Word),
     /// TODO: Word might not actually valid in an expr in the TS Grammar
     Word(Word),
     /// Constant either PI or version
     Constant(Word),
 
+    Indexing(Box<Expression>, Index),
+
     /// An expression expansion `$(expr)`
     /// This expression is invalid in most cases, except in variable commands.
+
     /// This is because they cannot be nested
     VarRound(Box<Expression>),
 
@@ -57,6 +64,22 @@ pub enum Expression {
     /// This expression is invalid in most cases, except in variable commands.
     /// This is because they cannot be nested
     VarCurly(Ident),
+}
+
+#[derive(Debug, Default, PartialEq, PartialOrd, Clone)]
+pub enum Index {
+    Int(usize),
+    #[default]
+    Glob,
+}
+
+impl Display for Index {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Int(n) => write!(f, "{n}"),
+            Self::Glob => write!(f, "*"),
+        }
+    }
 }
 
 impl Display for Expression {
@@ -82,8 +105,10 @@ impl Display for Expression {
             }
             Self::Parens(expr) => write!(f, "({expr})"),
             Self::ThermoKeyword(kw) => write!(f, "{kw}"),
+            Self::AtomProperty(kw) => write!(f, "{kw}"),
             Self::Constant(cons) => write!(f, "{cons}"),
             Self::Word(word) => write!(f, "{word}"),
+            Self::Indexing(expr, index) => write!(f, "{expr}[{index}]"),
             Self::VarRound(expr) => write!(f, "$({expr})"),
             Self::VarCurly(var) => write!(f, "${{{var}}}"), // triple { to ensure escaping
         }
@@ -207,6 +232,7 @@ impl Expression {
                 _ => unreachable!(), // TODO: Verify this is the case?
             },
             "thermo_kwarg" => Ok(Self::ThermoKeyword(Word::parse_word(node, text))),
+            "atom_property" => Ok(Self::AtomProperty(Word::parse_word(node, text))),
             "constant" => Ok(Self::Constant(Word::parse_word(node, text))),
             "word" => Ok(Self::Word(Word::parse_word(node, text))),
             // TODO: merge this with word in the grammar
@@ -215,11 +241,36 @@ impl Expression {
             "identifier" => Ok(Self::Word(Word::parse_word(node, text))),
             "var_round" => Ok(Self::VarRound(Box::new(var_round(node, text)?))),
             "var_curly" => var_curly(node, text).map(Self::VarCurly),
+            "indexing" => indexing(node, text),
             "ERROR" => Err(ParseExprError::ErrorNode.into()),
             x => Err(ParseExprError::UnknownExpressionType(x.to_owned()).into()),
         }
         // todo!()
     }
+}
+
+pub(crate) fn indexing(node: &Node, text: &str) -> Result<Expression, FromNodeError> {
+    let value = node
+        .child_by_field_name("value")
+        .ok_or(FromNodeError::PartialNode("expected expression".into()))?;
+    // TODO: properly handle the `[]`
+    let value = Expression::parse_expression(&value, text)?;
+
+    let index = node
+        .child_by_field_name("index")
+        .ok_or(FromNodeError::PartialNode("expected index".into()))?;
+
+    let index = match index.str_text(text) {
+        "*" => Index::Glob,
+        x => {
+            let num = x.parse().map_err(|_| {
+                FromNodeError::PartialNode(format!["invalid index `{x}`, expected `*` or integer"])
+            })?;
+            Index::Int(num)
+        }
+    };
+
+    Ok(Expression::Indexing(Box::new(value), index))
 }
 
 pub(crate) fn var_round(node: &Node, text: &str) -> Result<Expression, FromNodeError> {
@@ -388,7 +439,7 @@ mod tests {
 
     use pretty_assertions::assert_eq;
 
-    use crate::ast::IdentType;
+    use crate::{ast::IdentType, utils};
 
     use super::*;
 
@@ -678,5 +729,30 @@ mod tests {
             )
         );
         assert_eq!(func.to_string(), "ramp(v_example, 3)")
+    }
+
+    #[test]
+    fn indexed_variable() {
+        let src = "variable y equal x[1]";
+
+        let tree = utils::testing::parse(src);
+        dbg!(&tree.root_node().to_sexp());
+        let expr = tree
+            .root_node()
+            .child(0)
+            .expect("getting variable command")
+            .child(3)
+            .expect("Expression here");
+
+        assert_eq!(
+            Expression::parse_expression(&expr, src),
+            Ok(Expression::Indexing(
+                Box::new(Expression::AtomProperty(Word::new(
+                    "x".into(),
+                    (0, 17)..(0, 18)
+                ))),
+                Index::Int(1)
+            ))
+        )
     }
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -110,6 +110,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "incomplete test"]
     fn node_coverage() {
         const NODES_STR: &str = tree_sitter_lammps::NODE_TYPES;
 

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -89,6 +89,8 @@ pub fn ts_to_ast(tree: &Tree, text: &str) -> Result<Ast, PartialAst> {
 #[allow(clippy::expect_used)]
 mod tests {
 
+    use serde_json::Value;
+
     // use pretty_assertions::assert_eq;
     use crate::utils::testing::parse;
 
@@ -103,6 +105,23 @@ mod tests {
 
         let _ast = ts_to_ast(&tree, source);
         // dbg!(ast.unwrap());
+
+        unimplemented!()
+    }
+
+    #[test]
+    fn node_coverage() {
+        const NODES_STR: &str = tree_sitter_lammps::NODE_TYPES;
+
+        std::fs::write("./node_types.json", NODES_STR).expect("Failed to write node types out.");
+        let value: Value = serde_json::from_str(NODES_STR).expect("Failed to deserialise");
+
+        dbg!(&value);
+
+        // dbg!(NODES_STR);
+        for node_type in value.as_array().expect("top level should be an array") {
+            dbg!(node_type);
+        }
 
         unimplemented!()
     }


### PR DESCRIPTION
Synchronises with the tree-sitter grammar and adds support for atom properties and more general indexing in expressions.

Internally also adds a helper method for dealing with errors and Nodes being missing.