### PR TITLE
Tree sitter changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,6 +1137,8 @@ dependencies = [
 [[package]]
 name = "tree-sitter-lammps"
 version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3203f9d0cd72a05d458f2c412f7549f61d4c0714727ffe165d9248d9a332d3c"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-lammps"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1136,9 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-lammps"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf381143b234ae8ec73d0cc4399f4370af5c865dc0c9305b955734fb5db1d70d"
+version = "0.0.7"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1136,9 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-lammps"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac33c6f09df70517970981c29c7e39653aa65a9cc788bb964eb5df0241f0b23c"
+checksum = "cf381143b234ae8ec73d0cc4399f4370af5c865dc0c9305b955734fb5db1d70d"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ tokio = { version = "1.40.0", features = [
 ] }
 tower-lsp = "0.20.0"
 tree-sitter = "0.23.0"
-tree-sitter-lammps = "0.0.7"
+tree-sitter-lammps = "0.0.8"
 
 [dev-dependencies]
 criterion = { version = "=0.5.1", features = ["html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ exclude = ["/ci", "images/", ".*", "bacon.toml", "_typos.toml"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[patch.crates-io]
+tree-sitter-lammps = { path = "../tree-sitter-lammps/" }
+
 [build-dependencies]
 cc = "1.0"
 
@@ -37,7 +40,7 @@ tokio = { version = "1.40.0", features = [
 ] }
 tower-lsp = "0.20.0"
 tree-sitter = "0.23.0"
-tree-sitter-lammps = "0.0.6"
+tree-sitter-lammps = "0.0.7"
 
 [dev-dependencies]
 criterion = { version = "=0.5.1", features = ["html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,6 @@ exclude = ["/ci", "images/", ".*", "bacon.toml", "_typos.toml"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[patch.crates-io]
-tree-sitter-lammps = { path = "../tree-sitter-lammps/" }
 
 [build-dependencies]
 cc = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ exclude = ["/ci", "images/", ".*", "bacon.toml", "_typos.toml"]
 [build-dependencies]
 cc = "1.0"
 
+[features]
+ast_panics = []
+
 [dependencies]
 anyhow = "1.0.72"
 clap = { version = "4.5", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ tokio = { version = "1.40.0", features = [
 ] }
 tower-lsp = "0.20.0"
 tree-sitter = "0.23.0"
-tree-sitter-lammps = "0.0.5"
+tree-sitter-lammps = "0.0.6"
 
 [dev-dependencies]
 criterion = { version = "=0.5.1", features = ["html_reports"] }

--- a/example_input_scripts/in.nemd
+++ b/example_input_scripts/in.nemd
@@ -149,4 +149,3 @@ run  2
 fix # Here to show what happens with in-complete commands.
 
 
-

--- a/example_input_scripts/in.syntax_errors
+++ b/example_input_scripts/in.syntax_errors
@@ -1,3 +1,4 @@
+
 # test
 variable a equal lx
 

--- a/src/ast/arguments.rs
+++ b/src/ast/arguments.rs
@@ -163,6 +163,9 @@ impl FromNode for ArgumentKind {
             }
             // TODO: It seems weird sending something called error through ok.
             "ERROR" => Ok(Self::Error),
+            // NOTE: make this variant a panic for testing purposes.
+            #[cfg(feature = "ast_panics")]
+            c => panic!("unknown argument kind {c}"),
             x => Err(FromNodeError::UnknownCustom {
                 kind: "argument type".to_string(),
                 name: x.to_string(),

--- a/src/ast/arguments.rs
+++ b/src/ast/arguments.rs
@@ -34,7 +34,7 @@ pub enum ArgumentKind {
     ArgName(String), // TODO: Is this still in use in the tree-sitter grammar?
     /// Variable expansion within curly braces
     VarCurly(Ident),
-    /// A simple variable expansion in $var
+    /// A simple variable expansion in $v
     SimpleExpansion(Ident),
     /// Expression evaluations in $()
     VarRound(Expression),

--- a/src/ast/commands.rs
+++ b/src/ast/commands.rs
@@ -103,7 +103,8 @@ impl FromNode for Command {
             "compute" => Ok(Self::Compute(
                 ast::ComputeDef::from_node(node, &text).map_err(error_span)?,
             )),
-            "variable_def" => Ok(Self::VariableDef(
+            // TODO: Make a variable deltion it's own type
+            "variable_def" | "variable_del" => Ok(Self::VariableDef(
                 ast::VariableDef::from_node(node, &text).map_err(error_span)?,
             )),
             "shell" => Ok(Self::Shell(node.range().into())),
@@ -111,6 +112,11 @@ impl FromNode for Command {
             "command" => Ok(Self::GenericCommand(
                 GenericCommand::from_node(node, &text).map_err(error_span)?,
             )),
+            "ERROR" => Ok(Self::Error(node.range().into())),
+
+            // NOTE: make this variant a panic for testing purposes.
+            #[cfg(feature = "ast_panics")]
+            c => panic!("unknown command kind {c}"),
             _ => Ok(Self::Error(node.range().into())),
         };
 
@@ -119,7 +125,7 @@ impl FromNode for Command {
             // and pass to that parser.
 
             result = match node.child(0).map(|node| node.kind()) {
-                // Try and pass this as a compute
+                // Try and parse this as a compute
                 Some("compute") => Ok(Self::Compute(
                     ast::ComputeDef::from_node(node, &text).map_err(error_span)?,
                 )),

--- a/src/ast/compute_def.rs
+++ b/src/ast/compute_def.rs
@@ -86,7 +86,7 @@ mod test {
 
     #[test]
     fn parse_compute_with_args() {
-        let source = "compute T_hot water temp/region hot_region";
+        let source = "compute T_hot water temp/region hot_region\n";
 
         let tree = parse(source);
 

--- a/src/ast/expressions.rs
+++ b/src/ast/expressions.rs
@@ -261,10 +261,15 @@ impl Expression {
             "identifier" => Ok(Self::Word(Word::parse_word(node, text))),
             "var_round" => Ok(Self::VarRound(Box::new(var_round(node, text)?))),
             "var_curly" => var_curly(node, text).map(Self::VarCurly),
-            "simple_expansion" => Ok(Self::SimpleExpansion(Ident::new(
-                &node.child(1).into_err()?,
-                text,
-            )?)),
+            "simple_expansion" => {
+                let ident = Ident::new(&node.child(1).into_err()?, text)?;
+                if ident.name.len() > 1 {
+                    return Err(FromNodeError::PartialNode(
+                        "simple expansions only support one character variables ".into(),
+                    ));
+                }
+                Ok(Self::SimpleExpansion(ident))
+            }
             "indexing" => indexing(node, text),
             "ERROR" => Err(ParseExprError::ErrorNode.into()),
             #[cfg(feature = "ast_panics")]

--- a/src/ast/expressions.rs
+++ b/src/ast/expressions.rs
@@ -258,6 +258,8 @@ impl Expression {
             "var_curly" => var_curly(node, text).map(Self::VarCurly),
             "indexing" => indexing(node, text),
             "ERROR" => Err(ParseExprError::ErrorNode.into()),
+            #[cfg(feature = "ast_panics")]
+            exp => panic!("unknown expression kind {exp}"),
             x => Err(ParseExprError::UnknownExpressionType(x.to_owned()).into()),
         }
         // todo!()

--- a/src/ast/expressions.rs
+++ b/src/ast/expressions.rs
@@ -4,11 +4,15 @@
 
 use std::fmt::Display;
 
+use itertools::Itertools;
 use tree_sitter::Node;
 
 use crate::{
     ast::Ident,
-    utils::{into_error::IntoError, tree_sitter_helpers::NodeExt},
+    utils::{
+        into_error::IntoError,
+        tree_sitter_helpers::{ExpectNode, NodeExt},
+    },
 };
 use std::convert::TryFrom;
 use thiserror::Error;
@@ -212,27 +216,30 @@ impl Expression {
                 UnaryOp::try_from(node.child(0).into_err()?.str_text(text))?,
                 Self::parse_expression(&node.child(1).into_err()?, text)?.into(),
             )),
-            "binary_func" | "unary_func" | "ternary_func" | "hexnary_func" | "other_func"
-            | "group_func" | "region_func" => {
+            "func" => {
                 let mut cursor = node.walk();
-
-                let mut args = Vec::new();
-                let name_node = &node.child(0).into_err()?;
-                let name = Word::parse_word(name_node, text);
 
                 // child 0 = function name
                 // child 1 = opening bracket
+                // child 2 = argument list.
+                // child 3 = bracket
+
+                let name_node = &node.child(0).into_err()?;
+                let name = Word::parse_word(name_node, text);
+                let arg_list_node = node
+                    .child_by_field_name("args")
+                    .expect_kind("argument_list", "missing list of arguments")?;
+
                 // TODO: Handle no closing bracket!!!!
-                for node in node.children(&mut cursor).skip(2) {
-                    node.str_text(text);
-                    if node.kind() == ")" {
-                        break;
-                    }
-                    if node.kind() == "," {
-                        continue;
-                    }
-                    args.push(Self::parse_expression(&node, text)?);
-                }
+                let args = arg_list_node
+                    .children(&mut cursor)
+                    .skip(1)
+                    .take_while(|node| node.kind() != ")")
+                    // TODO: This is assuming properly formed interleaved arg and comma
+                    .filter(|node| node.kind() != ",")
+                    .map(|node| Self::parse_expression(&node, text))
+                    .try_collect()?;
+
                 Ok(Self::Function(name, args))
             }
 
@@ -717,7 +724,7 @@ mod tests {
     }
 
     #[test]
-    fn func_display() {
+    fn test_func() {
         let mut parser = setup_parser();
         let source = "variable a equal ramp(v_example, 3.0)";
 

--- a/src/ast/fix_def.rs
+++ b/src/ast/fix_def.rs
@@ -113,7 +113,8 @@ mod test {
 
     #[test]
     fn parse_fix_with_args() {
-        let source = "fix NVT all nvt temp 1 1.5 $(100.0*dt)";
+        let source = "fix NVT all nvt temp 1 1.5 $(100.0*dt)
+";
 
         let tree = parse(source);
 

--- a/src/ast/impl_helpers.rs
+++ b/src/ast/impl_helpers.rs
@@ -24,7 +24,7 @@ impl ast::Ast {
         })
     }
 
-    // TODO: Is this lifetime bound correct?
+    // TODO: Is this lifetime bound correct? Check that jonhoo talk on return postition impl traits
     /// Find the spans of commands before a each run command.
     ///
     /// These spans start at the end of the previous run command and end at the start of the
@@ -38,8 +38,8 @@ impl ast::Ast {
 
         // The spans of the blocks of commands defined before run commands.
         std::iter::once(Span {
-            start: Default::default(),
-            end: Default::default(),
+            start: (0, 0).into(),
+            end: (0, 0).into(),
         })
         .chain(run_spans)
         .tuple_windows()

--- a/src/ast/variable_def.rs
+++ b/src/ast/variable_def.rs
@@ -149,7 +149,7 @@ mod test {
 
     #[test]
     fn parse_index_variable() {
-        let text = "variable file_name index step4.1.atm";
+        let text = "variable file_name index step4.1.atm\n";
         // let text = include_str!("../../example_input_scripts/in.variable_index");
 
         let tree = parse(text);
@@ -194,7 +194,7 @@ mod test {
 
     #[test]
     fn parse_incomplete_variable_def() {
-        let source = "variable a equal";
+        let source = "variable a equal\n";
 
         let tree = parse(source);
 

--- a/src/ast/variable_def.rs
+++ b/src/ast/variable_def.rs
@@ -63,7 +63,7 @@ impl FromNode for VariableDef {
 
         let args = args?;
 
-        if args.is_empty() {
+        if variable_kind.contents != "delete" && args.is_empty() {
             return Err(Self::Error::PartialNode(
                 "missing arguments in variable command".to_string(),
             ));

--- a/src/check_commands/fixes/mod.rs
+++ b/src/check_commands/fixes/mod.rs
@@ -100,7 +100,7 @@ mod tests {
 
     #[test]
     fn bad_check_n_args() {
-        let text = "fix profw water  ave/chunk 1 $(v_nsteps) $(v_nsteps)";
+        let text = "fix profw water  ave/chunk 1 $(v_nsteps) $(v_nsteps)\n";
         let tree = parse(text);
         let node = tree.root_node().child(0).unwrap();
         let fix = FixDef::from_node(&node, text).unwrap();

--- a/src/check_commands/fixes/nose_hoover.rs
+++ b/src/check_commands/fixes/nose_hoover.rs
@@ -147,7 +147,7 @@ mod tests {
 
     #[test]
     fn valid_nvt() {
-        let text = "fix NVT all nvt temp 1 $(v_T*1.5) $(100*dt)";
+        let text = "fix NVT all nvt temp 1 $(v_T*1.5) $(100*dt)\n";
         let tree = parse(text);
         let node = tree.root_node().child(0).unwrap();
         let fix = FixDef::from_node(&node, text).unwrap();
@@ -162,7 +162,7 @@ mod tests {
 
     #[test]
     fn valid_npt() {
-        let text = "fix NPT all npt temp 1 $(v_T*1.5) $(100*dt) iso 1 $(v_p*1.5) ${pdamp}";
+        let text = "fix NPT all npt temp 1 $(v_T*1.5) $(100*dt) iso 1 $(v_p*1.5) ${pdamp}\n";
         let tree = parse(text);
         let node = tree.root_node().child(0).unwrap();
         let fix = FixDef::from_node(&node, text).unwrap();
@@ -177,7 +177,7 @@ mod tests {
 
     #[test]
     fn complicated_nph() {
-        let text = "fix 2 ice nph x 1.0 1.0 0.5 y 2.0 2.0 0.5 z 3.0 3.0 0.5 yz 0.1 0.1 0.5 xz 0.2 0.2 0.5 xy 0.3 0.3 0.5 nreset 1000";
+        let text = "fix 2 ice nph x 1.0 1.0 0.5 y 2.0 2.0 0.5 z 3.0 3.0 0.5 yz 0.1 0.1 0.5 xz 0.2 0.2 0.5 xy 0.3 0.3 0.5 nreset 1000\n";
         let tree = parse(text);
         let node = tree.root_node().child(0).unwrap();
         let fix = FixDef::from_node(&node, text).unwrap();
@@ -192,7 +192,7 @@ mod tests {
 
     #[test]
     fn invalid_nvt() {
-        let text = "fix NVT all nvt temp 1.0 $(v_T*1.5) TEMP";
+        let text = "fix NVT all nvt temp 1.0 $(v_T*1.5) TEMP\n";
         let tree = parse(text);
         let node = tree.root_node().child(0).unwrap();
         let fix = FixDef::from_node(&node, text).unwrap();

--- a/src/check_commands/utils.rs
+++ b/src/check_commands/utils.rs
@@ -60,6 +60,7 @@ pub(crate) fn kwarg_expected_floats<'a>(
                 ArgumentKind::Int(_) => (),
                 ArgumentKind::VarRound(_) => (),
                 ArgumentKind::VarCurly(_) => (),
+                ArgumentKind::SimpleExpansion(_) => (),
                 _ => Err(invalid_arguments::InvalidArgumentsType::IncorrectType {
                     expected: "float".into(),
                     provided: x.to_string(),

--- a/src/check_commands/utils.rs
+++ b/src/check_commands/utils.rs
@@ -180,14 +180,16 @@ mod tests {
 
     #[test]
     fn invalid_zero_arg_fix() {
-        let text = "fix NVE all nve asdfas";
+        let text = "fix NVE all nve asdfas\n";
         let tree = parse(text);
         let node = tree.root_node().child(0).unwrap();
+        dbg!(&node.to_sexp());
         let fix = FixDef::from_node(&node, text).unwrap();
 
         assert_eq!(fix.fix_id.name, "NVE");
         assert_eq!(fix.group_id.contents, "all");
         assert_eq!(fix.fix_style, FixStyle::Nve);
+        dbg!(&fix.args);
         assert!(!fix.args.is_empty());
 
         assert_eq!(

--- a/src/utils/tree_sitter_helpers.rs
+++ b/src/utils/tree_sitter_helpers.rs
@@ -10,12 +10,25 @@ pub(crate) trait NodeExt {
     /// Panics if node offset somehow is on invalid UTF-8 character boundaries.
     /// This should only happen if the file wasn't UTF-8 encoded.
     fn str_text<'a>(&self, source: &'a str) -> &'a str;
+
+    /// The number of lines the node spans.
+    fn n_lines(&self) -> usize;
 }
 
 impl NodeExt for Node<'_> {
     fn str_text<'a>(&self, source: &'a str) -> &'a str {
         // Should not panic as source is valid utf-8
         self.utf8_text(source.as_bytes()).expect("invalid utf-8")
+    }
+
+    fn n_lines(&self) -> usize {
+        let tree_sitter::Range {
+            start_point,
+            end_point,
+            ..
+        } = self.range();
+
+        end_point.row - start_point.row + 1
     }
 }
 

--- a/tests/in.variables
+++ b/tests/in.variables
@@ -1,0 +1,19 @@
+variable x index run1 run2 run3 run4 run5 run6 run7 run8
+variable LoopVar loop $n
+variable beta equal temp/3.0
+variable b1 equal x[234]+0.5*vol
+variable b1 equal "x[234] + 0.5*vol"
+variable b equal xcm(mol1,x)/2.0
+variable b equal c_myTemp
+variable b atom x*y/vol
+variable foo string myfile
+variable foo internal 3.5
+variable myPy python increase
+variable f file values.txt
+variable temp world 300.0 310.0 320.0 ${Tfinal}
+variable x universe 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15
+variable x uloop 15 pad
+variable str format x %.6g
+variable myvec vector [1,3,7,10]
+variable x delete
+


### PR DESCRIPTION
Adds support for newly supported features in the tree-sitter grammar

- Simple expansions within expressions
- A single function type
- Identifiers within expressions that aren't keywords
- Raw strings 
- Triple quoted strings