### PR TITLE
Updates to support tree-sitter grammar changes

### DIFF
--- a/src/ast/arguments.rs
+++ b/src/ast/arguments.rs
@@ -78,7 +78,6 @@ impl FromNode for Argument {
     type Error = FromNodeError;
 
     fn from_node(node: &Node, text: &str) -> Result<Self, Self::Error> {
-        let text = text.as_ref();
         let kind = ArgumentKind::from_node(node, text)?;
 
         Ok(Argument {
@@ -96,7 +95,6 @@ impl FromNode for ArgumentKind {
         text: &str,
     ) -> Result<Self, <Argument as FromNode>::Error> {
         // TODO: make these variants more complete.
-        let text = text.as_ref();
         match node.kind() {
             "int" => Ok(Self::Int(node.str_text(text).parse::<isize>()?)),
             "float" => Ok(Self::Float(node.str_text(text).parse::<f64>()?)),
@@ -311,6 +309,9 @@ impl Display for ArgumentKind {
 
 #[cfg(test)]
 mod test {
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::expect_used)]
+
     use pretty_assertions::assert_eq;
 
     use crate::utils;

--- a/src/ast/compute_def.rs
+++ b/src/ast/compute_def.rs
@@ -31,7 +31,6 @@ impl FromNode for ComputeDef {
         let mut cursor = node.walk();
 
         let mut children = node.children(&mut cursor);
-        let text = text.as_ref();
 
         // skip the compute keyword
         children.next();
@@ -77,6 +76,9 @@ impl FromNode for ComputeDef {
 
 #[cfg(test)]
 mod test {
+    // Allowed within the tests
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::expect_used)]
 
     use pretty_assertions::assert_eq;
 

--- a/src/ast/fix_def.rs
+++ b/src/ast/fix_def.rs
@@ -34,7 +34,6 @@ impl FromNode for FixDef {
     fn from_node(node: &Node, text: &str) -> Result<Self, Self::Error> {
         let span = node.range().into();
         let mut cursor = node.walk();
-        let text = text.as_ref();
 
         let mut children = node.children(&mut cursor);
 
@@ -72,6 +71,9 @@ impl FromNode for FixDef {
 
 #[cfg(test)]
 mod test {
+    // Allowed within the tests
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::expect_used)]
 
     use pretty_assertions::assert_eq;
 

--- a/src/ast/impl_helpers.rs
+++ b/src/ast/impl_helpers.rs
@@ -16,7 +16,7 @@ impl ast::Ast {
     pub fn find_run_commands(&self) -> impl Iterator<Item = &ast::Command> {
         // TODO: also include `minimize` and `rerun` commands
         self.commands.iter().filter(|cmd| {
-            if let ast::Command::GenericCommand(c) = &cmd {
+            if let ast::Command::Generic(c) = &cmd {
                 c.name.contents == "run"
             } else {
                 false

--- a/src/ast/variable_def.rs
+++ b/src/ast/variable_def.rs
@@ -100,6 +100,9 @@ impl FromNode for VariableDef {
 
 #[cfg(test)]
 mod test {
+    // Allowed within the tests
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::expect_used)]
 
     use pretty_assertions::assert_eq;
 

--- a/src/check_commands.rs
+++ b/src/check_commands.rs
@@ -56,7 +56,7 @@ impl Ast {
             }
             // Not sure about other named commands yet...
             Command::Compute(compute) => check_compute(compute).err().map(InvalidCommand::from),
-            Command::GenericCommand(command) => {
+            Command::Generic(command) => {
                 let command_name = CommandName::from(command.name.as_str());
 
                 if let CommandName::InvalidCommand(name) = command_name {

--- a/src/check_styles.rs
+++ b/src/check_styles.rs
@@ -35,7 +35,7 @@ pub fn check_styles(ast: &Ast, tree: &Tree, text: &str) -> Vec<InvalidStyle> {
     // Check pair styles
     // TODO: Also check other types of style.
     for command in &ast.commands {
-        if let ast::Command::GenericCommand(cmd) = &command {
+        if let ast::Command::Generic(cmd) = &command {
             if cmd.name.contents != "pair_style" {
                 continue;
             }

--- a/src/error_finder.rs
+++ b/src/error_finder.rs
@@ -122,6 +122,12 @@ impl ErrorFinder {
     }
 }
 
+impl Default for ErrorFinder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Debug for ErrorFinder {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ErrorFinder")
@@ -239,7 +245,7 @@ impl MissingToken {
 impl Issue for MissingToken {
     fn diagnostic(&self) -> crate::diagnostics::Diagnostic {
         crate::diagnostics::Diagnostic {
-            name: "Missing Token".into(),
+            name: "Missing Token",
             severity: crate::diagnostics::Severity::Error,
             span: Span {
                 start: self.start,

--- a/src/identifinder.rs
+++ b/src/identifinder.rs
@@ -98,7 +98,6 @@ impl IdentiFinder {
 
     /// Create a new `Identifinder` and search for symbols.
     pub fn new(tree: &Tree, text: &str) -> Result<Self, FromNodeError> {
-        let text = text.as_ref();
         let mut i = Self::new_no_parse();
         i.find_symbols(tree, text)?;
         Ok(i)

--- a/src/input_script.rs
+++ b/src/input_script.rs
@@ -131,7 +131,7 @@ impl<'src> InputScript<'src> {
     }
 
     fn find_syntax_errors(&mut self) {
-        let syntax_errors = self.error_finder.find_errors(&self.tree, &self.source_code);
+        let syntax_errors = self.error_finder.find_errors(&self.tree, self.source_code);
         self.diagnostics
             .extend(syntax_errors.iter().map(|x| x.diagnostic()));
     }
@@ -174,7 +174,7 @@ impl<'src> InputScript<'src> {
 }
 
 fn get_ast(tree: &Tree, source_code: &str) -> (Ast, impl Iterator<Item = Diagnostic>) {
-    let ast = ts_to_ast(&tree, source_code);
+    let ast = ts_to_ast(tree, source_code);
 
     let (ast, ast_errors) = match ast {
         Ok(ast) => (ast, vec![]),

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -238,7 +238,7 @@ impl LanguageServer for Backend {
                     DOCS_MAP.computes().get(compute_style)
                 }
 
-                Command::GenericCommand(GenericCommand { name, .. }) => {
+                Command::Generic(GenericCommand { name, .. }) => {
                     let name = CommandName::from(name.as_str());
                     DOCS_MAP.commands().get(&name)
                 }

--- a/src/utils/tree_sitter_helpers.rs
+++ b/src/utils/tree_sitter_helpers.rs
@@ -58,7 +58,7 @@ impl<'a> ExpectNode for Option<Node<'a>> {
 
                 Ok(x)
             }
-            None => return Err(FromNodeError::PartialNode(message.into())),
+            None => Err(FromNodeError::PartialNode(message.into())),
         }
     }
 
@@ -71,7 +71,7 @@ impl<'a> ExpectNode for Option<Node<'a>> {
 
                 Ok(x)
             }
-            None => return Err(FromNodeError::PartialNode(message.into())),
+            None => Err(FromNodeError::PartialNode(message.into())),
         }
     }
 }


### PR DESCRIPTION
The tree-sitter grammar now supports single and triple quoted strings.
Functions can now have any name, to reduce confusing errors.
